### PR TITLE
Fix for IP_TOS warning

### DIFF
--- a/patches/PR1.patch
+++ b/patches/PR1.patch
@@ -31,26 +31,6 @@ index 3b380d9..05d0e7e 100644
  #ifdef HAVE_STRUCT_PASSWD_PW_GECOS
  	fake.pw_gecos = "NOUSER";
  #endif
-diff --git a/configure b/configure
-index 9ad9699..bdc3df3 100755
---- a/configure
-+++ b/configure
-@@ -15525,6 +15525,7 @@ _ACEOF
- if ac_fn_c_try_run "$LINENO"
- then :
- 
-+      chtag -tc 819 conftest.sslincver
- 			ssl_header_ver=`cat conftest.sslincver`
- 			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ssl_header_ver" >&5
- printf "%s\n" "$ssl_header_ver" >&6; }
-@@ -15610,6 +15611,7 @@ _ACEOF
- if ac_fn_c_try_run "$LINENO"
- then :
- 
-+      chtag -tc 819 conftest.ssllibver
- 			ssl_library_ver=`cat conftest.ssllibver`
- 			# Check version is supported.
- 			case "$ssl_library_ver" in
 diff --git a/defines.h b/defines.h
 index 279e509..e07adf2 100644
 --- a/defines.h

--- a/patches/configure.patch
+++ b/patches/configure.patch
@@ -1,0 +1,32 @@
+diff --git a/configure b/configure
+index 9ad9699..341d6e9 100755
+--- a/configure
++++ b/configure
+@@ -9060,6 +9060,11 @@ fi
+ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+ }
+ 	;;
++*openedition*)
++
++  printf "%s\n" "#define IP_TOS_IS_BROKEN 1" >>confdefs.h
++  ;;
++
+ *-*-dgux*)
+ 
+ printf "%s\n" "#define IP_TOS_IS_BROKEN 1" >>confdefs.h
+@@ -15525,6 +15530,7 @@ _ACEOF
+ if ac_fn_c_try_run "$LINENO"
+ then :
+ 
++      chtag -tc 819 conftest.sslincver
+ 			ssl_header_ver=`cat conftest.sslincver`
+ 			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ssl_header_ver" >&5
+ printf "%s\n" "$ssl_header_ver" >&6; }
+@@ -15610,6 +15616,7 @@ _ACEOF
+ if ac_fn_c_try_run "$LINENO"
+ then :
+ 
++      chtag -tc 819 conftest.ssllibver
+ 			ssl_library_ver=`cat conftest.ssllibver`
+ 			# Check version is supported.
+ 			case "$ssl_library_ver" in

--- a/patches/configure.patch
+++ b/patches/configure.patch
@@ -14,19 +14,3 @@ index 9ad9699..341d6e9 100755
  *-*-dgux*)
  
  printf "%s\n" "#define IP_TOS_IS_BROKEN 1" >>confdefs.h
-@@ -15525,6 +15530,7 @@ _ACEOF
- if ac_fn_c_try_run "$LINENO"
- then :
- 
-+      chtag -tc 819 conftest.sslincver
- 			ssl_header_ver=`cat conftest.sslincver`
- 			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ssl_header_ver" >&5
- printf "%s\n" "$ssl_header_ver" >&6; }
-@@ -15610,6 +15616,7 @@ _ACEOF
- if ac_fn_c_try_run "$LINENO"
- then :
- 
-+      chtag -tc 819 conftest.ssllibver
- 			ssl_library_ver=`cat conftest.ssllibver`
- 			# Check version is supported.
- 			case "$ssl_library_ver" in


### PR DESCRIPTION
Fixes: `setsockopt socket 4 IP_TOS 72: EDC8109I Protocol not available.`